### PR TITLE
Use vagant-hostsupdater plugin to manage /etc/hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,22 +17,18 @@ you can build out the complete stack:
 $ mkdir ~/kalastack
 $ cd ~/kalastack
 $ git clone git://github.com/kalamuna/kalastack.git ./
+$ vagrant plugin install vagrant-hostsupdater
 $ vagrant box add kalabox http://files.vagrantup.com/precise64.box
 $ vagrant up kalabox --provision-with=shell,puppet_server
 ```
+
+You should now be able to access http://start.kala in your browser!
+
 To ssh into your server, from within ~/kalastack, issue:
 ```bash
 $ vagrant ssh
 ````
 ## Post Install Checks
-
-### VHOSTS
-
-Add the following entry to /etc/hosts on your host system. On Windows XP this is located at c:\WINDOWS\system32\drivers\etc\hosts
-
-    192.168.42.10 start.kala php.kala grind.kala kala
-
-You should now be able to access http://start.kala in your browser!
 
 
 ### YOUR FILES

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,6 +25,8 @@ Vagrant.configure("2") do |config|
     # Create a private network, which allows host-only access to the machine
     # using a specific IP.
     kalabox.vm.network :private_network, ip: "192.168.42.10"
+    kalabox.vm.hostname = "kala"
+    kalabox.hostsupdater.aliases = ["start.kala", "php.kala", "grind.kala"]
   
     # Create a public network, which generally matched to bridged network.
     # Bridged networks make the machine appear as another physical device on

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure("2") do |config|
     # Create a private network, which allows host-only access to the machine
     # using a specific IP.
     kalabox.vm.network :private_network, ip: "192.168.42.10"
-    kalabox.vm.hostname = "kala"
     kalabox.hostsupdater.aliases = ["start.kala", "php.kala", "grind.kala"]
   
     # Create a public network, which generally matched to bridged network.


### PR DESCRIPTION
https://github.com/cogitatio/vagrant-hostsupdater

There's also `vagrant-hostmaster`, but it seems to be stalled on an old vagrant version since the maintainers aren't updating:
https://github.com/mosaicxm/vagrant-hostmaster/issues/24

PR forthcoming.
