### PR TITLE
Use vagrant-vbguest to make sure the guest addition matches the vbox version running

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ you can build out the complete stack:
 $ mkdir ~/kalastack
 $ cd ~/kalastack
 $ git clone git://github.com/kalamuna/kalastack.git ./
+$ vagrant plugin install vagrant-vbguest
 $ vagrant box add kalabox http://files.vagrantup.com/precise64.box
 $ vagrant up kalabox --provision-with=shell,puppet_server
 ```


### PR DESCRIPTION
It's not always the case that it matters that the guestadditions version in the VM matches the host's version, but a mismatch has been the source of many quirky failures on the vbox end of things.

https://github.com/dotless-de/vagrant-vbguest

(The travis-ci project recommends it for working with the baseboxes they offer, if that helps convince.)
