### PR TITLE
Don't use kalabox variable in multiple scopes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -107,22 +107,22 @@ Vagrant.configure("2") do |config|
     "
     
     kalabox.vm.provision :shell, :inline => $script
-    kalabox.vm.provision :puppet_server do |kalabox|
-      kalabox.puppet_server = "kalabox.kalamuna.com"
-      kalabox.options = "--verbose --debug --test"
-      kalabox.facter = {
+    kalabox.vm.provision :puppet_server do |puppet|
+      puppet.puppet_server = "kalabox.kalamuna.com"
+      puppet.options = "--verbose --debug --test"
+      puppet.facter = {
         "vagrant" => "1",
         "kalauser" => "vagrant",
         "kalahost" => "192.168.42.1",
       }
     end
     # should not ever run this provisioner except for development
-    kalabox.vm.provision :puppet do |start|
-       start.manifests_path = "manifests"
-       start.manifest_file  = "site.pp"
-       start.module_path = "modules"
-       start.options = "--verbose --debug"
-       start.facter = {
+    kalabox.vm.provision :puppet do |puppet|
+       puppet.manifests_path = "manifests"
+       puppet.manifest_file  = "site.pp"
+       puppet.module_path = "modules"
+       puppet.options = "--verbose --debug"
+       puppet.facter = {
         "vagrant" => "1",
         "kalauser" => "vagrant",
         "kalahost" => "192.168.42.1",


### PR DESCRIPTION
Just a heads up, but I think this might come back to bite you later:
https://github.com/kalamuna/kalastack/blob/2.x/Vagrantfile#L110

Notice that you're using `kalabox` at both the vm-level config and also at the provisioner level. I don't think it's hurting you now, but the provisioner-level configs might override the higher level ones if they share key names

The official vagrant template would suggest that `kalabox` and `puppet_server` are a little more fitting:
https://github.com/mitchellh/vagrant/blob/master/templates/commands/init/Vagrantfile.erb#L78

I might recommend we stick with their approach, if only for clarity? Whaddaya think? :)
