### PR TITLE
Added Integer typecast.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,7 +47,7 @@ Vagrant.configure("2") do |config|
   elsif hostker == "Linux" then
     hostmem = Integer(%x[ grep MemTotal /proc/meminfo ].scan(/\d+/).shift) / 1024
   else
-    hostmem = conf["default_memory"]
+    hostmem = Integer(conf["default_memory"])
   end
 
   # Set a hard maximum on memsize


### PR DESCRIPTION
While attempting to install/use kalastack on my Windows 7 system, "vagrant up" command gave error

  Vagrantfile:55:in `>': comparison of String with 12288 failed (ArgumentError)

This fix adds the Integer typecast so that var hostmem is assigned a value of type Integer, not String.

---

You guys are doing great work. Thanks so much. Look forward to getting kalastack working.

Btw, I'm new to github and the proper workflow for making contributions, so please let me know if I'm not following the proper procedures.
