### PR TITLE
Update to Node.js 4 Stable

### DIFF
--- a/modules/frontend/manifests/prepare.pp
+++ b/modules/frontend/manifests/prepare.pp
@@ -9,7 +9,7 @@ class frontend::prepare {
   exec { "preparenode":
     path    => "/bin:/usr/bin",
     unless  => "which node",
-    command => "curl -sL https://deb.nodesource.com/setup | sudo bash -",
+    command => "curl -sL https://deb.nodesource.com/setup_4.x | bash -",
     require => Class["phpfpm::extensions::curl"],
   }
 


### PR DESCRIPTION
The currently installed version of node is unsupported and deprecated. [Node.js](https://nodejs.org) 4.2.3 LTS is out, and is stable.
