### PR TITLE
GBZ-1238 Do not install node_modules globally

### DIFF
--- a/modules/frontend/manifests/packages.pp
+++ b/modules/frontend/manifests/packages.pp
@@ -7,8 +7,7 @@ class frontend::packages {
 
   exec { "nodepackages":
     path    => "/bin:/usr/bin",
-    unless  => "npm list -g --depth=0 | grep grunt-cli",
-    command => "npm install -g coffee-script bower grunt-cli gulp component yo",
+    command => "echo Node.js $(node --version) - npm $(npm --version)",
     require => Exec["preparepackages"],
   }
 


### PR DESCRIPTION
It causes file permission errors. Let the application install the packages locally instead. This makes it just output the node and npm version instead. Seems like a good way of debugging.
